### PR TITLE
Fix genesis block creation

### DIFF
--- a/h2testnet.sh
+++ b/h2testnet.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+java -cp lib/h2*.jar org.h2.tools.Shell -url jdbc:h2:./nxt_test_db/nxt -user sa -password sa

--- a/src/java/nxt/BlockchainProcessorImpl.java
+++ b/src/java/nxt/BlockchainProcessorImpl.java
@@ -1402,32 +1402,11 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
                 digest.update(transaction.bytes());
             }
             Logger.logInfoMessage("Done updating digest for Genesis Creation");
-            // ToDo: Clean this up after the DB has been verified
-            //BlockImpl genesisBlock = new BlockImpl(-1, 0, 0, Constants.MAX_BALANCE_NQT, 0, transactions.size() * 128, digest.digest(),
-            //        Genesis.CREATOR_PUBLIC_KEY, new byte[64], Genesis.GENESIS_BLOCK_SIGNATURE, null, transactions, 0L, null); // nonce 0 and no ATs
+            BlockImpl genesisBlock = new BlockImpl(-1, 0, 0L, 0L, 0L, transactions.size() * 128, digest.digest(),
+                    Genesis.CREATOR_ID, Genesis.GENESIS_GENERATION_SIGNATURE, Genesis.GENESIS_BLOCK_SIGNATURE, 
+                    null, Genesis.GENESIS_CUMULATIVE_DIFFICULTY, Genesis.GENESIS_BASE_TARGET, 0L, 0, Genesis.GENESIS_BLOCK_ID,
+                    transactions, 0L, null); // nonce 0 and no ATs
 
-            ByteBuffer bf = ByteBuffer.allocate( 0 );
-            bf.order( ByteOrder.LITTLE_ENDIAN );
-            byte[] byteATs = bf.array();
-
-/*
-            BlockImpl genesisBlock = new BlockImpl(-1, 0, 0, 0, 0, transactions.size() * 128, digest.digest(),
-                    Genesis.CREATOR_PUBLIC_KEY, new byte[32], Genesis.GENESIS_BLOCK_SIGNATURE, null, transactions, 0L, byteATs);
-*/
-
-            /*BlockImpl(int version, int timestamp, long previousBlockId, long totalAmountNQT, long totalFeeNQT, int payloadLength,
-            byte[] payloadHash, long generatorId, byte[] generationSignature, byte[] blockSignature,
-            byte[] previousBlockHash, BigInteger cumulativeDifficulty, long baseTarget, long nextBlockId, int height, long id,
-            List<TransactionImpl> blockTransactions, Long nonce, byte[] blockATs)        */
-            BlockImpl genesisBlock = new BlockImpl(-1, 0, 0, 0, 0, 0,
-                                                   // version   timestamp    previousblock    AmountNQT         totalFee      //payload length
-                    digest.digest(), 8628161281313630310L, new byte[32], Genesis.GENESIS_BLOCK_SIGNATURE,
-                //  payloadhash      generatorID                 gen sig       block Sig
-                    null, BigInteger.ZERO, 0,0L, 0, 1,
-                //  previosuhash         diff                baseTarget, nextBlockID     height   id
-                    transactions, 0L, new byte[0]);
-                // transactions        nonce       bytesAT
-            //byteATs
             Logger.logInfoMessage("Ready to addBlock(genesisBlock)");
             addBlock(genesisBlock);
             Logger.logInfoMessage("Genesis Block added successfully");

--- a/src/java/nxt/Genesis.java
+++ b/src/java/nxt/Genesis.java
@@ -16,25 +16,35 @@
 
 package nxt;
 
+import java.math.BigInteger;
+
 public final class Genesis {
 
     public static final long GENESIS_BLOCK_ID = 3444294670862540038L;
-    public static final long CREATOR_ID = 8628161281313630310L; // Takened from production
+    public static final long CREATOR_ID = 8628161281313630310L; // Taken from production, a-k-a BURST-NU58-Z4QR-XXKE-94DHH
     public static final byte[] CREATOR_PUBLIC_KEY = {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
 
+    // initial payments in the genesis block
+    // these were used in NXT to spread out the initial stakeholders' BTC
+    // but in BURST there was no IPO so these are empty
     public static final long[] GENESIS_RECIPIENTS = {};
-
-
     public static final int[] GENESIS_AMOUNTS = {};
-
     public static final byte[][] GENESIS_SIGNATURES = {};
 
-    public static final byte[] GENESIS_BLOCK_SIGNATURE = new byte[]{
+    public static final byte[] GENESIS_BLOCK_SIGNATURE = new byte[] {
             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     };
+    
+    public static final byte[] GENESIS_GENERATION_SIGNATURE = new byte[] {
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    };
+    
+    public static final BigInteger GENESIS_CUMULATIVE_DIFFICULTY = new BigInteger(0, new byte[] {});
+    
+    public static final long GENESIS_BASE_TARGET = 18325193796L;
 
     private Genesis() {} // never
 


### PR DESCRIPTION
Should fix SQL constraint failure when starting up for the 2nd time
(was basically wrong column values for block id, base target, etc.)

also added h2test.sh script to allow command line access to H2 testnet database files