### PR TITLE
More changes to allow blockchain download from old v1.2.x peers

### DIFF
--- a/src/java/nxt/Account.java
+++ b/src/java/nxt/Account.java
@@ -540,8 +540,7 @@ public final class Account {
 
         @Override
         protected void save(Connection con, Account account) throws SQLException {
-            //account.save(con);
-            account.save();
+            account.save(con);
         }
 
     };
@@ -1211,11 +1210,7 @@ public final class Account {
     }
 
     private void save(Connection con) throws SQLException {
-        // XXX BURST: This is commented out in old BURST - but WHY?
-        // Adding forced throw here to enable the code path and find out when it's called
-        throw new RuntimeException("Account.save(con) code path was called - this is forbidden in BURST - WHY?");
-        
-        /*
+        // BURST: This was commented out in old BURST - but WHY?
         try (PreparedStatement pstmt = con.prepareStatement("MERGE INTO account (id, "
                 + "balance, unconfirmed_balance, forged_balance, "
                 + "active_lessee_id, has_control_phasing, height, latest) "
@@ -1230,7 +1225,6 @@ public final class Account {
             pstmt.setInt(++i, Nxt.getBlockchain().getHeight());
             pstmt.executeUpdate();
         }
-        */
     }
 
     private void save() {

--- a/src/java/nxt/BlockchainProcessorImpl.java
+++ b/src/java/nxt/BlockchainProcessorImpl.java
@@ -445,9 +445,9 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
 
         private List<Long> getBlockIdsAfterCommon(final Peer peer, final long startBlockId, final boolean countFromStart) {
             long matchId = startBlockId;
-            List<Long> blockList = new ArrayList<>(720);
+            List<Long> blockList = new ArrayList<>(1440); // compatibility with old BURST v1.2.x peers
             boolean matched = false;
-            int limit = countFromStart ? 720 : 1440;
+            int limit = 1440; // compatibility with old BURST v1.2.x peers
             while (true) {
                 JSONObject request = new JSONObject();
                 request.put("requestType", "getNextBlockIds");
@@ -482,11 +482,11 @@ final class BlockchainProcessorImpl implements BlockchainProcessor {
                         }
                     } else {
                         blockList.add(blockId);
-                        if (blockList.size() >= 720) {
+                        if (blockList.size() >= limit) {
                             break;
                         }
                     }
-                    if (countFromStart && ++count >= 720) {
+                    if (countFromStart && ++count >= limit) {
                         break;
                     }
                 }


### PR DESCRIPTION
Reverted commenting-out of code for saving Account rows into database inherited from old BURST.
Not sure of the historic reasons but future breakage might reveal the reason!

Changed results limit to 1440 when requesting getNextBlockIds from peers
to aid compatibility from old v1.2.x peers