### PR TITLE
fix incorrect NXT code stopping multiple set-account-info messages in…

### DIFF
--- a/src/java/nxt/Constants.java
+++ b/src/java/nxt/Constants.java
@@ -162,7 +162,7 @@ public final class Constants {
     public static final int PHASING_BLOCK = isTestnet ? 0 : 360000;
     public static final int CHECKSUM_BLOCK_16 = isTestnet ? 0 : 360000;
     // BURST: Following constant is abused a lot for various non-shuffling purposes, like calculate minimum fee support
-    public static final int SHUFFLING_BLOCK = isTestnet ? 0 : 360000;
+    public static final int SHUFFLING_BLOCK = isTestnet ? 2500 : 360000;
     public static final int CHECKSUM_BLOCK_17 = isTestnet ? 0 : 360000;
     public static final int CHECKSUM_BLOCK_18 = isTestnet ? 0 : 360000;
     public static final int CHECKSUM_BLOCK_19 = isTestnet ? 0 : 360000;

--- a/src/java/nxt/TransactionType.java
+++ b/src/java/nxt/TransactionType.java
@@ -1308,7 +1308,7 @@ public abstract class TransactionType {
             @Override
             boolean isBlockDuplicate(Transaction transaction, Map<TransactionType, Map<String, Integer>> duplicates) {
                 return Nxt.getBlockchain().getHeight() > Constants.SHUFFLING_BLOCK
-                        && isDuplicate(Messaging.ACCOUNT_INFO, getName(), duplicates, true);
+                        && isDuplicate(Messaging.ACCOUNT_INFO, Long.toUnsignedString(transaction.getSenderId()), duplicates, true);
             }
 
             @Override
@@ -3051,7 +3051,7 @@ public abstract class TransactionType {
                 if (Nxt.getBlockchain().getHeight() < Constants.DIGITAL_GOODS_STORE_BLOCK) {
                     return false; // sync fails after 7007 without this
                 }
-                return TransactionType.isDuplicate(REWARD_RECIPIENT_ASSIGNMENT, Long.toUnsignedString(transaction.getSenderId()), duplicates, true);    // XXX Assuming "exclusive" based on old BURST
+                return TransactionType.isDuplicate(REWARD_RECIPIENT_ASSIGNMENT, Long.toUnsignedString(transaction.getSenderId()), duplicates, true);
             }
             
             @Override


### PR DESCRIPTION
… the same block (even though for different accounts)

(other transaction type isBlockDuplicate() and isDuplicate() calls still need fixing, e.g. POLL_CREATION)

set block height in pushBlock() instead of in every calling instance
(also allowed some code to be reverted back to base NXT)
note that BlockImpl block is no longer final inside pushBlock()

reapply 2500 as test DIGITAL_GOODS_STORE_BLOCK (somehow set to 0 sorry)